### PR TITLE
Release/W44-2019

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,6 @@
 {:deps {org.clojure/clojurescript {:mvn/version "1.10.520"}
         com.bhauman/figwheel-main {:mvn/version "0.2.3"}
+        binaryage/oops {:mvn/version "0.7.0"}
         cljsjs/pixi {:mvn/version "5.1.4-0"}}
 
  :paths ["src" "target" "resources"]

--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,7 @@
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [org.clojure/clojurescript "1.10.520"]
                  [org.clojure/core.async  "0.4.500"]
+                 [binaryage/oops "0.7.0"]
                  [cljsjs/pixi "5.1.2-0"]]
 
   :plugins [[lein-figwheel "0.5.19"]

--- a/src/minasss_games/director.cljs
+++ b/src/minasss_games/director.cljs
@@ -3,7 +3,8 @@
   scenes, providing a way to start a new scene and clean everything
   afterwards."
   (:require [minasss-games.pixi :as pixi]
-            [minasss-games.tween :as tween]))
+            [minasss-games.tween :as tween]
+            [oops.core :refer [oget]]))
 
 (def director_ (atom {}))
 
@@ -21,7 +22,7 @@
   [app]
   (.start (pixi/make-ticker update-step))
   (reset! director_ {:app app
-                     :app-stage (.-stage app)}))
+                     :app-stage (oget app "stage")}))
 
 (defmulti scene-cleanup :cleanup-scene)
 

--- a/src/minasss_games/experiments/awwwliens/intro.cljs
+++ b/src/minasss_games/experiments/awwwliens/intro.cljs
@@ -24,9 +24,9 @@
   []
   (scene/render
     [:animated-sprite {:spritesheet "images/awwwliens/anim/ufo.json"
-              :animation-speed 0.01
-              :position [300 200]
-              :name "ufo"}]))
+                       :animation-speed 0.01
+                       :position [300 200]
+                       :name "ufo"}]))
 
 (defn make-cow-still
   "Create cow still element"

--- a/src/minasss_games/pixi.cljs
+++ b/src/minasss_games/pixi.cljs
@@ -1,6 +1,7 @@
 (ns minasss-games.pixi
   "Simple wrapper around PIXI javascript library"
-  (:require [cljsjs.pixi]))
+  (:require [cljsjs.pixi]
+            [com.goog :as g]))
 
 
 (def Loader js/PIXI.Loader.shared)
@@ -166,37 +167,37 @@
 (defn set-name
   "Set name of any PIXI/DisplayObject subclass"
   [container name]
-  (aset container "name" name)
+  (g/set container "name" name)
   container)
 
 (defn set-text
   "Set text content of PIXI/Text instance"
   [container text]
-  (aset container "text" text)
+  (g/set container "text" text)
   container)
 
 (defn set-alpha
   "Set alpha of any PIXI/DisplayObject subclass"
   [container value]
-  (aset container "alpha" value)
+  (g/set container "alpha" value)
   container)
 
 (defn set-animation-speed
   "Set animation-speed of a PIXI/AnimatedSprite instance"
   [container value]
-  (aset container "animationSpeed" value)
+  (g/set container "animationSpeed" value)
   container)
 
 (defn set-visible
   "Set visibility of any PIXI/DisplayObject subclass"
   [container visible?]
-  (aset container "visible" visible?)
+  (g/set container "visible" visible?)
   container)
 
 (defn set-texture
   "Set texture of any PIXI/Sprite subclass"
   [container texture]
-  (aset container "texture" (get-texture texture))
+  (g/set container "texture" (get-texture texture))
   container)
 
 (defmulti set-attribute

--- a/src/minasss_games/pixi.cljs
+++ b/src/minasss_games/pixi.cljs
@@ -1,7 +1,7 @@
 (ns minasss-games.pixi
   "Simple wrapper around PIXI javascript library"
   (:require [cljsjs.pixi]
-            [com.goog :as g]))
+            [goog.object :as g]))
 
 
 (def Loader js/PIXI.Loader.shared)

--- a/src/minasss_games/pixi.cljs
+++ b/src/minasss_games/pixi.cljs
@@ -1,16 +1,16 @@
 (ns minasss-games.pixi
   "Simple wrapper around PIXI javascript library"
   (:require [cljsjs.pixi]
-            [goog.object :as g]))
+            [oops.core :refer [oget oset!]]))
 
 
-(def Loader js/PIXI.Loader.shared)
-(def Resources js/PIXI.Loader.shared.resources)
+(def Loader (oget js/PIXI.Loader "shared"))
+(def Resources (oget Loader "resources"))
 
 (defn add-app-to-dom
   "Add the specified app to the DOM"
   [app]
-  (js/document.body.appendChild (.-view app)))
+  (js/document.body.appendChild (oget app "view")))
 
 (defn make-ticker
   "Create a ticker registering an handler"
@@ -32,7 +32,7 @@
 
 (defn ^:export load-resources-progress-callback
   [loader resource]
-  (println "loading " (.-url resource) " , total " (.-progress loader)))
+  (println "loading " (oget resource "url") " , total " (oget loader "progress")))
 
 (defn load-resources
   "Load resourse specified by `resources` array, when finished
@@ -50,7 +50,7 @@
   (let [tex (aget Resources texture-name)]
     (if (nil? tex)
       (println "could not find texture " texture-name)
-      (.-texture tex))))
+      (oget tex "texture"))))
 
 (defn get-spritesheet
   "Return a spritesheet from the texture cache, by name"
@@ -58,7 +58,7 @@
   (let [res (aget Resources resource-name)]
     (if (nil? res)
       (println "could not find spritesheet " resource-name)
-      (.-spritesheet res))))
+      (oget res "spritesheet"))))
 
 (defn make-container
   "Create a PIXI container"
@@ -73,7 +73,7 @@
 (defn make-animated-sprite
   "Create a animated sprite prividing a spritesheet name"
   [spritesheet-name animation-name]
-  (js/PIXI.AnimatedSprite. (aget (.-animations (get-spritesheet spritesheet-name)) animation-name)))
+  (js/PIXI.AnimatedSprite. (aget (oget (get-spritesheet spritesheet-name) "animations") animation-name)))
 
 (defn add-child
   "Add child to provided parent container"
@@ -94,7 +94,7 @@
 (defn remove-container
   "Remove a container from the scene"
   [container]
-  (.removeChild (.-parent container) container))
+  (.removeChild (oget container "parent") container))
 
 (defn remove-child-by-name
   "Remove the child specified by name"
@@ -120,7 +120,7 @@
 (defn add-to-app-stage
   "Add container to application main stage"
   [app container]
-  (.addChild (.-stage app) container)
+  (.addChild (oget app "stage") container)
   container)
 
 (defn make-text-style
@@ -143,61 +143,61 @@
 (defn set-position
   "Set position of any PIXI/Container subclass"
   [container x y]
-  (.set (.-position container) x y)
+  (.set (oget container "position") x y)
   container)
 
 (defn set-anchor
   "Set anchor of any PIXI/Container subclass"
   [container x y]
-  (.set (.-anchor container) x y)
+  (.set (oget container "anchor") x y)
   container)
 
 (defn set-pivot
   "Set pivot of any PIXI/Container subclass"
   [container x y]
-  (.set (.-pivot container) x y)
+  (.set (oget container "pivot") x y)
   container)
 
 (defn set-scale
   "Set scale of any PIXI/Container subclass"
   [container x y]
-  (.set (.-scale container) x y)
+  (.set (oget container "scale") x y)
   container)
 
 (defn set-name
   "Set name of any PIXI/DisplayObject subclass"
   [container name]
-  (g/set container "name" name)
+  (oset! container "name" name)
   container)
 
 (defn set-text
   "Set text content of PIXI/Text instance"
   [container text]
-  (g/set container "text" text)
+  (oset! container "text" text)
   container)
 
 (defn set-alpha
   "Set alpha of any PIXI/DisplayObject subclass"
   [container value]
-  (g/set container "alpha" value)
+  (oset! container "alpha" value)
   container)
 
 (defn set-animation-speed
   "Set animation-speed of a PIXI/AnimatedSprite instance"
   [container value]
-  (g/set container "animationSpeed" value)
+  (oset! container "animationSpeed" value)
   container)
 
 (defn set-visible
   "Set visibility of any PIXI/DisplayObject subclass"
   [container visible?]
-  (g/set container "visible" visible?)
+  (oset! container "visible" visible?)
   container)
 
 (defn set-texture
   "Set texture of any PIXI/Sprite subclass"
   [container texture]
-  (g/set container "texture" (get-texture texture))
+  (oset! container "texture" (get-texture texture))
   container)
 
 (defmulti set-attribute

--- a/src/minasss_games/pixi/input.cljs
+++ b/src/minasss_games/pixi/input.cljs
@@ -26,9 +26,9 @@
   [event-name handler-identifier]
   (swap! handler-registry_
     (fn [handler-map]
-      (let [registry-key [event-name handler-identifier]])
-      (.removeEventListener js/document (get event-name-mapping event-name) (get handler-map registry-key)
-        (dissoc handler-map registry-key)))))
+      (let [registry-key [event-name handler-identifier]]
+        (.removeEventListener js/document (get event-name-mapping event-name) (get handler-map registry-key)
+          (dissoc handler-map registry-key))))))
 
 (defn register-keys
   "Tries to provide a higher level abstraction for key management"


### PR DESCRIPTION
thanks to clj-oops, and changing object property access to use oget to prevent name mangling by the Closure compiler, now the minified version of the code works.