### PR TITLE
Plot complex animations

### DIFF
--- a/src/minasss_games/director.cljs
+++ b/src/minasss_games/director.cljs
@@ -9,7 +9,7 @@
 
 (def director_ (atom {}))
 
-(defn update-step
+(defn ^:export update-step
   "update view related stuff"
   [delta-time]
   (screenplay/update-actions delta-time)
@@ -22,7 +22,7 @@
   - :current-scene optional, a map that contains information about current scene
     like init function, cleanup function and maybe something else in the future"
   [app]
-  (.start (pixi/make-ticker update-step))
+  (pixi/add-to-shared-ticker update-step)
   (reset! director_ {:app app
                      :app-stage (oget app "stage")}))
 

--- a/src/minasss_games/director.cljs
+++ b/src/minasss_games/director.cljs
@@ -3,6 +3,7 @@
   scenes, providing a way to start a new scene and clean everything
   afterwards."
   (:require [minasss-games.pixi :as pixi]
+            [minasss-games.screenplay :as screenplay]
             [minasss-games.tween :as tween]
             [oops.core :refer [oget]]))
 
@@ -11,6 +12,7 @@
 (defn update-step
   "update view related stuff"
   [delta-time]
+  (screenplay/update-actions delta-time)
   (tween/update-tweens delta-time))
 
 (defn init

--- a/src/minasss_games/director.cljs
+++ b/src/minasss_games/director.cljs
@@ -3,17 +3,30 @@
   scenes, providing a way to start a new scene and clean everything
   afterwards."
   (:require [minasss-games.pixi :as pixi]
+            [minasss-games.pixi.settings :as settings]
             [minasss-games.screenplay :as screenplay]
             [minasss-games.tween :as tween]
             [oops.core :refer [oget]]))
 
 (def director_ (atom {}))
 
+(def TargetFPMS (settings/get-by-name "TARGET_FPMS"))
+
 (defn ^:export update-step
-  "update view related stuff"
-  [delta-time]
-  (screenplay/update-actions delta-time)
-  (tween/update-tweens delta-time))
+  "update view related stuff
+  ticker callback will receive a parameter which is referred as
+  delta time by PIXI documentation; but this name is missleading because
+  instead of time since last update it refers to `frame time` since last frame
+  this means that if we target 60 FPS and we effectively have 60 FPS,
+  delta-time will have the value 1, if we have 30 FPS delta-time will have
+  the value 2; to make things more clear PIXI delta time will be called
+  `delta-frame`.
+  If we are interested in `real` delta-time we can scale delta-frame with
+  TargetFPMS: target frames per millisecond"
+  [delta-frame]
+  (let [dt-ms (* delta-frame TargetFPMS)]
+    (screenplay/update-actions dt-ms)
+    (tween/update-tweens dt-ms)))
 
 (defn init
   "Initialize the director which is basicly a map that holds

--- a/src/minasss_games/experiments/awwwliens/intro.cljs
+++ b/src/minasss_games/experiments/awwwliens/intro.cljs
@@ -6,6 +6,7 @@
             [minasss-games.pixi :as pixi]
             [minasss-games.pixi.input :as input]
             [minasss-games.pixi.scene :as scene]
+            [minasss-games.screenplay :as screenplay]
             [minasss-games.tween :as tween]
             [minasss-games.experiments.awwwliens.game :as game]))
 
@@ -18,6 +19,15 @@
                 "images/awwwliens/anim/ufo.json"])
 
 (def main-stage (pixi/make-container))
+
+(def intro-plot [[:screenplay/move
+                  :actor :cow
+                  :from [0 0] :to [100 100] :speed 30
+                  :then [:screenplay/after
+                         :time 500
+                         :then [:screenplay/move
+                         :actor :ufo
+                         :from [0 0] :to [100 100] :speed 50]]]])
 
 (defn make-animated-ufo
   "Create animated ufo element"

--- a/src/minasss_games/experiments/awwwliens/intro.cljs
+++ b/src/minasss_games/experiments/awwwliens/intro.cljs
@@ -28,13 +28,18 @@
           :actor :ufo
           :from [0 0] :to [248 200] :speed 10
           :then [screenplay/action-after
-                 :time 5.0
+                 :time 10.0
                  :then [[screenplay/action-scale
                          :actor :cow
-                         :from 0.1 :to 1.0 :time 0.5]
+                         :from 0.1 :to 1.0 :time 25.0]
                         [screenplay/action-move
                          :actor :cow
                          :from [248 200] :to [248 400] :speed 5]]]]])
+
+(comment
+  (let [container (pixi/get-child-by-name main-stage "cow")]
+    (pixi/set-attributes container {:scale 0.5}))
+  )
 
 (defn screenplay-listener
   [_event-type action payload]

--- a/src/minasss_games/experiments/awwwliens/intro.cljs
+++ b/src/minasss_games/experiments/awwwliens/intro.cljs
@@ -23,18 +23,18 @@
 (def main-stage (pixi/make-container))
 
 (def intro-screenplay
-  [screenplay/action-after :time 50
+  [screenplay/action-after :time 1.5
    :then [screenplay/action-move
           :actor :ufo
           :from [0 0] :to [248 200] :speed 10
           :then [screenplay/action-after
-                 :time 10.0
+                 :time 3.0
                  :then [[screenplay/action-scale
                          :actor :cow
-                         :from 0.1 :to 1.0 :time 25.0]
+                         :from 0.1 :to 1.0 :time 5.0]
                         [screenplay/action-move
                          :actor :cow
-                         :from [248 200] :to [248 400] :speed 5]]]]])
+                         :from [248 200] :to [248 400] :speed 40]]]]])
 
 (comment
   (let [container (pixi/get-child-by-name main-stage "cow")]

--- a/src/minasss_games/experiments/awwwliens/intro.cljs
+++ b/src/minasss_games/experiments/awwwliens/intro.cljs
@@ -25,21 +25,20 @@
 (def intro-screenplay
   [screenplay/action-after :time 50
    :then [screenplay/action-move
-          :actor :cow
-          :from [0 400] :to [248 400] :speed 10
+          :actor :ufo
+          :from [0 0] :to [248 200] :speed 10
           :then [screenplay/action-after
                  :time 5.0
-                 :then [screenplay/action-move
-                        :actor :ufo
-                        :from [0 0] :to [200 200] :speed 10]]]])
+                 :then [[screenplay/action-scale
+                         :actor :cow
+                         :from 0.1 :to 1.0 :time 0.5]
+                        [screenplay/action-move
+                         :actor :cow
+                         :from [248 200] :to [248 400] :speed 5]]]]])
 
 (defn screenplay-listener
   [_event-type action payload]
-  (clog "screenplay listener event action payload")
-  (clog _event-type)
-  (clog (clj->js action))
-  (clog (clj->js payload))
-  (when-let [actor (:actor action)]
+  (when-let [actor (:actor payload)]
     (let [container (pixi/get-child-by-name main-stage (name actor))]
       (pixi/set-attributes container (:state payload)))))
 
@@ -50,7 +49,7 @@
               [:animated-sprite {:spritesheet "images/awwwliens/anim/ufo.json"
                                  :animation-name "ufo"
                                  :animation-speed 0.05
-                                 :position [200 200]
+                                 :position [-200 -200]
                                  :name "ufo"}])]
     (.play ufo)
     ufo))
@@ -60,7 +59,7 @@
   []
   (scene/render
     [:sprite {:texture "images/awwwliens/menu/cow-still.png"
-              :position [0 400]
+              :position [-200 -400]
               :name "cow"}]))
 
 (def menu-items_ (atom {:selected-index 0
@@ -120,7 +119,9 @@
 (defn handle-input
   [event-type _native action]
   (if (= :key-up event-type)
-    (update-menu! action)))
+    (if (= ::restart-screenplay action)
+      (screenplay/start intro-screenplay screenplay-listener)
+      (update-menu! action))))
 
 (defn setup
   "setup the view based on the menu-items_ atom; main-stage refers to the
@@ -139,7 +140,8 @@
   (setup main-stage)
   (input/register-keys {"ArrowUp" ::move-up "k" ::move-up "w" ::move-up
                         "ArrowDown" ::move-down "j" ::move-down "s" ::move-down
-                        "Enter" ::select "Space" ::select}
+                        "Enter" ::select "Space" ::select
+                        "r" ::restart-screenplay}
     ::menu-handler handle-input)
   )
 

--- a/src/minasss_games/experiments/awwwliens/intro.cljs
+++ b/src/minasss_games/experiments/awwwliens/intro.cljs
@@ -20,24 +20,24 @@
 
 (def main-stage (pixi/make-container))
 
-(def intro-plot [[:screenplay/move
-                  :actor :cow
-                  :from [0 0] :to [100 100] :speed 30
-                  :then [:screenplay/after
-                         :time 500
-                         :then [:screenplay/move
-                         :actor :ufo
-                         :from [0 0] :to [100 100] :speed 50]]]])
+(def intro-screenplay [[screenplay/action-move
+                        :actor :cow
+                        :from [0 400] :to [248 400] :speed 60
+                        :then [screenplay/action-after
+                               :time 500
+                               :then [screenplay/action-move
+                                      :actor :ufo
+                                      :from [0 0] :to [200 200] :speed 80]]]])
 
 (defn make-animated-ufo
   "Create animated ufo element"
   []
   (let [ufo (scene/render
-          [:animated-sprite {:spritesheet "images/awwwliens/anim/ufo.json"
-                             :animation-name "ufo"
-                             :animation-speed 0.05
-                             :position [200 200]
-                             :name "ufo"}])]
+              [:animated-sprite {:spritesheet "images/awwwliens/anim/ufo.json"
+                                 :animation-name "ufo"
+                                 :animation-speed 0.05
+                                 :position [200 200]
+                                 :name "ufo"}])]
     (.play ufo)
     ufo))
 
@@ -47,7 +47,7 @@
   (scene/render
     [:sprite {:texture "images/awwwliens/menu/cow-still.png"
               :position [248 400]
-              :name "cow-stil"}]))
+              :name "cow"}]))
 
 (def menu-items_ (atom {:selected-index 0
                         :items [{:text "Press Enter\nTo Play" :position [-90 100]}
@@ -108,6 +108,12 @@
   (if (= :key-up event-type)
     (update-menu! action)))
 
+(defn screenplay-listener
+  [_event-type action payload]
+  (when (not (= action :screenplay/after))
+    (let [container (pixi/get-child-by-name main-stage (name (:actor payload)))]
+      (pixi/set-attributes container (:state payload)))))
+
 (defn setup
   "setup the view based on the menu-items_ atom; main-stage refers to the
   root container, where other graphical elements will be added"
@@ -117,6 +123,8 @@
     (pixi/add-child main-stage (make-cow-still))
     (pixi/add-child main-stage (make-animated-ufo))
     (pixi/add-child main-stage (make-menu @menu-items_))
+
+    (screenplay/start intro-screenplay screenplay-listener)
     (add-watch menu-items_ ::menu-changed-watch menu-changed-listener)))
 
 (defn ^:export loaded-callback []

--- a/src/minasss_games/experiments/awwwliens/intro.cljs
+++ b/src/minasss_games/experiments/awwwliens/intro.cljs
@@ -35,7 +35,7 @@
 
 (defn screenplay-listener
   [_event-type action payload]
-  (clog "screenplay lisetner event action payload")
+  (clog "screenplay listener event action payload")
   (clog _event-type)
   (clog (clj->js action))
   (clog (clj->js payload))

--- a/src/minasss_games/experiments/awwwliens/view.cljs
+++ b/src/minasss_games/experiments/awwwliens/view.cljs
@@ -50,7 +50,7 @@
   (tween/move-to {:target (get-in @world-view_ [:cow :view])
                   :starting-position (to-world-position from-pos)
                   :target-position (to-world-position to-pos)
-                  :speed 3
+                  :speed 100
                   :on-complete on-complete-fn}))
 
 (defn update-score-text

--- a/src/minasss_games/experiments/awwwliens/view.cljs
+++ b/src/minasss_games/experiments/awwwliens/view.cljs
@@ -43,8 +43,7 @@
 
 (defn to-world-position
   [{:keys [col row]}]
-  {:x (* cell-width col)
-   :y (* cell-height row)})
+  [(* cell-width col) (* cell-height row)])
 
 (defn move-cow
   [from-pos to-pos on-complete-fn]

--- a/src/minasss_games/math.cljs
+++ b/src/minasss_games/math.cljs
@@ -4,7 +4,7 @@
 (defn direction
   "Given two vectors a and b, return a new vector that points from a to b"
   [[ax ay] [bx by]]
-  [(- ax ba) (- ay by)])
+  [(- ax bx) (- ay by)])
 
 (defn length
   "Given the vector v return its length"

--- a/src/minasss_games/math.cljs
+++ b/src/minasss_games/math.cljs
@@ -3,22 +3,26 @@
 
 (defn direction
   "Given two vectors a and b, return a new vector that points from a to b"
-  [a b]
-  (let [dx (- (:x a) (:x b))
-        dy (- (:y a) (:y b))]
-    {:x dx :y dy}))
+  [[ax ay] [bx by]]
+  [(- ax ba) (- ay by)])
 
 (defn length
   "Given the vector v return its length"
-  [v]
-  (let [x (:x v)
-        y (:y v)]
-    (Math/sqrt (+ (* x x) (* y y)))))
+  [[x y]]
+  (Math/sqrt (+ (* x x) (* y y))))
 
 (defn normalize
   "Given the vector v return its normalized version"
-  [v]
-  (let [x (:x v)
-        y (:y v)
-        len (Math/sqrt (+ (* x x) (* y y)))]
-    {:x (/ x len) :y (/ y len)}))
+  [[x y]]
+  (let [len (Math/sqrt (+ (* x x) (* y y)))]
+    [(/ x len) (/ y len)]))
+
+(defn scale
+  "Given the vector v return its scaled version"
+  [[x y] scale]
+  [(* x scale) (* y scale)])
+
+(defn translate
+  "Given the vector v return its translated version"
+  [[x y] [tx ty]]
+  [(+ x tx) (+ y ty)])

--- a/src/minasss_games/pixi.cljs
+++ b/src/minasss_games/pixi.cljs
@@ -6,6 +6,7 @@
 
 (def Loader (oget js/PIXI.Loader "shared"))
 (def Resources (oget Loader "resources"))
+(def Ticker (oget js/PIXI.Ticker "shared"))
 
 (defn add-app-to-dom
   "Add the specified app to the DOM"
@@ -18,6 +19,11 @@
   (let [ticker (js/PIXI.Ticker.)]
     (.add ticker handler-fn)
     ticker))
+
+(defn add-to-shared-ticker
+  "Add a listerner to the shared ticker"
+  [handler-fn]
+  (.add Ticker handler-fn))
 
 (defn make-app
   "Instantiate a PIXI app"
@@ -174,9 +180,11 @@
 
 (defn set-scale
   "Set scale of any PIXI/Container subclass"
-  [container x y]
-  (.set (oget container "scale") x y)
-  container)
+  ([container scale]
+   (set-scale scale scale))
+  ([container x y]
+   (.set (oget container "scale") x y)
+   container))
 
 (defn set-name
   "Set name of any PIXI/DisplayObject subclass"
@@ -236,6 +244,12 @@
 (defmethod set-attribute :pivot
   [container _attribute [x y]]
   (set-pivot container x y))
+
+(defmethod set-attribute :scale
+  ([container _attribute scale]
+   (set-scale container scale scale))
+  ([container _attribute x y]
+   (set-scale container x y)))
 
 (defmethod set-attribute :name
   [container _attribute name]

--- a/src/minasss_games/pixi.cljs
+++ b/src/minasss_games/pixi.cljs
@@ -155,7 +155,7 @@
 (defn set-position
   "Set position of any PIXI/Container subclass"
   ([container [x y]]
-   (set-position x y))
+   (set-position container x y))
   ([container x y]
    (.set (oget container "position") x y)
    container))

--- a/src/minasss_games/pixi.cljs
+++ b/src/minasss_games/pixi.cljs
@@ -154,9 +154,11 @@
 
 (defn set-position
   "Set position of any PIXI/Container subclass"
-  [container x y]
-  (.set (oget container "position") x y)
-  container)
+  ([container [x y]]
+   (set-position x y))
+  ([container x y]
+   (.set (oget container "position") x y)
+   container))
 
 (defn set-anchor
   "Set anchor of any PIXI/Container subclass"

--- a/src/minasss_games/pixi.cljs
+++ b/src/minasss_games/pixi.cljs
@@ -181,7 +181,8 @@
 (defn set-scale
   "Set scale of any PIXI/Container subclass"
   ([container scale]
-   (set-scale scale scale))
+   (.set (oget container "scale") scale scale)
+   container)
   ([container x y]
    (.set (oget container "scale") x y)
    container))

--- a/src/minasss_games/pixi/settings.cljs
+++ b/src/minasss_games/pixi/settings.cljs
@@ -3,15 +3,18 @@
   (compared to using js directly)
 
   PIXI.settings is an associative array so it is possible to access and set its
-  properties using aget/aset")
+  properties using aget/aset"
+  (:require [oops.core :refer [oget oget+ oset!+]]))
 
-(defn get-by-name!
-  [name value]
-  (aget js/PIXI.settings name))
+(def Settings (oget js/PIXI "settings"))
+
+(defn get-by-name
+  [name]
+  (oget+ Settings name))
 
 (defn set-by-name!
   [name value]
-  (aset js/PIXI.settings name value))
+  (oset!+ Settings name value))
 
 (defmulti set!
   (fn [setting _param] setting))

--- a/src/minasss_games/plot.cljs
+++ b/src/minasss_games/plot.cljs
@@ -1,0 +1,106 @@
+(ns minasss-games.plot
+  "Here is a way to define complex plots like the one described below
+  ```
+  [[:fade-in :time 1000 :actor :scene]
+  [:after :time 500
+  :then [
+    [:wait-all :actions
+      [:move :actor :bob :from [0 100] :to [100 100] :time 1000]
+      [:move :actor :alice :from [300 100] :to [110 100] :time 900]
+      :then [:show :target :menu]
+    ]]]]
+  ```
+  To make it possible to use different backends the plot should work
+  independently of the pixi code (i.e. updating containers, sprite etc),
+  instead it should provide a callback mechanism with at least three events:
+  - start: subscribers will receive the initial context (whatever it means)
+  - step: subscribers will receive the step update (for example current pos)
+  - finish: subscribers will receive the last state and maybe the next action
+
+  Event listeners will receive event-type, action and a payload which may be
+  different for each kind of actions, as a convention the ::start payload
+  will contain the initial state and the actor (if it makes sense), ::step and
+  ::finish will contain the actor, old-state and state.
+
+  This protocol is not well defined yet and will probably change in the
+  future."
+  (:require [minasss-games.math :as math]))
+
+;; Replicating the action namespace for now, to not break existing
+;; existing functionality
+
+(def actions-registry_ (atom (list)))
+
+(defn register-action
+  [action]
+  (swap! actions-registry_ conj action))
+
+(defmulti updater
+  (fn [action _delta-time] (:action action)))
+
+(defn update-actions
+  [delta-time]
+  (swap! actions-registry_
+    (fn [action]
+      (->> action
+        (map #(updater % delta-time))
+        (filter some?)
+        doall))))
+
+(defmethod updater ::move
+  [action delta-time]
+  (let [{:keys [actor position target-position direction prev-distance speed]} (:params action)
+        new-position {:x (+ (:x position) (* delta-time speed (:x direction)))
+                      :y (+ (:y position) (* delta-time speed (:y direction)))}
+        distance (math/length (math/direction target-position new-position))
+        listener (:listener action)
+        listener-payload {:actor actor
+                          :old-state {:position position}
+                          :state {:position new-position}}]
+    (if (> distance prev-distance)
+      ;; lifecycle of this action finishes here;
+      ;; if :dispatcher is set call dispatch function with the latest state
+      ;; of the action
+      (do
+        (listener ::finish (:action action) listener-payload)
+        ;; return the next action if any
+        ;; :then should be associated to a function that returns a new action
+        (when-let [next-action (:then action)]
+          (next-action)))
+      ;; this action has not finished yet, in updates the target and
+      ;; prepares the state for next iteration
+      (do
+        (listener ::step (:action action) listener-payload)
+        ;; return the current state of the action for the next iteration
+        (update-in action [:params] assoc :position new-position :prev-distance distance)))))
+
+(defn move
+  []
+  )
+
+(defmulti make-action (fn [action _dispatcher _options]) action)
+
+(defmethod make-action ::move
+  [_action listener options]
+  (let [{:keys [actor from to speed]} (apply hash-map options) ;; options are provided as a vector but it is pratical to access them as a map
+        dir (math/direction to from)
+        normalized-dir (math/normalize dir)
+        prev-distance (math/length dir)
+        then (when-let options)]
+    (listener ::start action {:actor actor
+                              :state {:position from}})
+    (register-action
+      {:action ::move
+       :listener listener
+       :params {:actor actor
+                :position from
+                :target-position to
+                :direction normalized-dir
+                :prev-distance prev-distance
+                :speed speed}})))
+
+(defn make-plot
+  "A plot is a tree like structure defined as a vector;
+  first item represent the action; the rest of the vector represents
+  options specified as pairs like :time 500, :actor :bob and so on"
+  [plot-spec listener])

--- a/src/minasss_games/screenplay.cljs
+++ b/src/minasss_games/screenplay.cljs
@@ -20,7 +20,7 @@
   Event listeners will receive event-type, action and a payload which may be
   different for each kind of actions, as a convention the ::start payload
   will contain the initial state and the actor (if it makes sense), ::step and
-  ::finish will contain the actor, old-state and state.
+  ::finish will contain the actor, old-state and (current) state.
 
   This protocol is not well defined yet and will probably change in the
   future."

--- a/src/minasss_games/tween.cljs
+++ b/src/minasss_games/tween.cljs
@@ -26,14 +26,15 @@
   [tween delta-time]
   (let [{:keys [target position target-position direction prev-distance speed]} (:params tween)
         on-complete (:on-complete tween)
-        new-position {:x (+ (:x position) (* delta-time speed (:x direction)))
-                      :y (+ (:y position) (* delta-time speed (:y direction)))}
+        new-position (->> (* delta-time speed)
+                       (math/scale direction )
+                       (math/translate position ))
         distance (math/length (math/direction target-position new-position))]
     (if (> distance prev-distance)
       ;; lifecycle of this tween finishes here; if on-complete returns
       ;; something that seems a tween return it so it can be registered
       (do
-        (pixi/set-position target (:x target-position) (:y target-position))
+        (pixi/set-position target target-position)
         (when (some? on-complete)
           (let [next-tween (on-complete)]
             (when (and (map? next-tween) (some? (:tween next-tween)))
@@ -41,7 +42,7 @@
       ;; this tween has not finished yet, in updates the target and
       ;; prepares the state for next iteration
       (do
-        (pixi/set-position target (:x new-position) (:y new-position))
+        (pixi/set-position target new-position)
         (update-in tween [:params] assoc :position new-position :prev-distance distance)))))
 
 (defn move-to


### PR DESCRIPTION
In the same spirit of "container declaration mini language" here is a new mini language to define screenplays which are used to create complex animations that can affect multiple actors.

In this PR it is also included a fix regarding delta-time calculation used to update tween and now screenplays; before this fix delta-time referred to frames per seconds meaning that a value of 1 represented a stable FPS and a value of 2 means that the game is running at half of the specified frame rate (60 by default)