### PR TITLE
Refactor pixi/scene >element

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
-{:deps {org.clojure/clojurescript {:mvn/version "1.10.520"}
+{:deps {org.clojure/clojurescript {:mvn/version "1.10.597"}
         com.bhauman/figwheel-main {:mvn/version "0.2.3"}
         binaryage/oops {:mvn/version "0.7.0"}
         cljsjs/pixi {:mvn/version "5.1.4-0"}}

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
   :min-lein-version "2.9.1"
 
   :dependencies [[org.clojure/clojure "1.10.0"]
-                 [org.clojure/clojurescript "1.10.520"]
+                 [org.clojure/clojurescript "1.10.597"]
                  [org.clojure/core.async  "0.4.500"]
                  [binaryage/oops "0.7.0"]
                  [cljsjs/pixi "5.1.2-0"]]

--- a/src/minasss_games/core.cljs
+++ b/src/minasss_games/core.cljs
@@ -1,7 +1,7 @@
 (ns minasss-games.core
   "A small experiment with PIXI javascript library"
-  (:require [minasss-games.director :as director]
-            [minasss-games.pixi :as pixi]
+  (:require [minasss-games.pixi :as pixi]
+            [minasss-games.director :as director]
             [minasss-games.experiments.awwwliens.intro :as awwwliens]))
             ;; [minasss-games.experiments.harvest-bot :as harvest-bot]))
 

--- a/src/minasss_games/director.cljs
+++ b/src/minasss_games/director.cljs
@@ -23,9 +23,7 @@
 
 (def director_ (atom {}))
 
-(def TargetFPMS (settings/get-by-name "TARGET_FPMS"))
-
-(defn ^:export update-step
+(defn update-step
   "update view related stuff
   ticker callback will receive a parameter which is referred as
   delta time by PIXI documentation; but this name is missleading because
@@ -37,7 +35,8 @@
   If we are interested in `real` delta-time we can scale delta-frame with
   TargetFPMS: target frames per millisecond"
   [delta-frame]
-  (let [dt-ms (* delta-frame TargetFPMS)]
+  (let [target-fpms (settings/get-by-name "TARGET_FPMS")
+        dt-ms (* delta-frame target-fpms)]
     (screenplay/update-actions dt-ms)
     (tween/update-tweens dt-ms)))
 

--- a/src/minasss_games/element.cljs
+++ b/src/minasss_games/element.cljs
@@ -1,4 +1,4 @@
-(ns minasss-games.pixi.scene
+(ns minasss-games.element
   "It would be AWESOME to use a language like hiccup to define a scene or a
   container, it could look something like this
   `[:container {:anchor [0 0] :position [100 100]}

--- a/src/minasss_games/experiments/awwwliens/intro.cljs
+++ b/src/minasss_games/experiments/awwwliens/intro.cljs
@@ -1,16 +1,18 @@
 (ns minasss-games.experiments.awwwliens.intro
-  "Here I am trying to animate the intro where the alien kidnap the cow
-  It should be super fun!
+  "Here I am trying to animate the intro where the alien drops the cow in its
+  new environment.
+  It should be super fun! But it is not :)
   Maybe the intro could go together with the main menu"
-  (:require [minasss-games.director :as director :refer [scene-init
-                                                         scene-ready
-                                                         scene-key-up
-                                                         scene-cleanup]]
+  (:require [minasss-games.director
+             :as
+             director
+             :refer
+             [scene-cleanup scene-init scene-key-up scene-ready]]
+            [minasss-games.element :as element]
+            [minasss-games.experiments.awwwliens.game :as game]
             [minasss-games.pixi :as pixi]
             [minasss-games.pixi.input :as input]
-            [minasss-games.pixi.scene :as scene]
-            [minasss-games.screenplay :as screenplay]
-            [minasss-games.experiments.awwwliens.game :as game]))
+            [minasss-games.screenplay :as screenplay]))
 
 (def clog js/console.log)
 
@@ -58,7 +60,7 @@
 (defn make-animated-ufo
   "Create animated ufo element"
   []
-  (let [ufo (scene/render
+  (let [ufo (element/render
               [:animated-sprite {:spritesheet "images/awwwliens/anim/ufo.json"
                                  :animation-name "ufo"
                                  :animation-speed 0.05
@@ -70,7 +72,7 @@
 (defn make-cow-still
   "Create cow still element"
   []
-  (scene/render
+  (element/render
     [:sprite {:texture "images/awwwliens/menu/cow-still.png"
               :position [-200 -400]
               :pivot [0.5 0.5]
@@ -92,7 +94,7 @@
 
 (defn make-menu
   [{:keys [selected-index items]}]
-  (scene/render
+  (element/render
     [:sprite {:name "menu"
               :anchor [1.0 0.0]
               :position [590 50]

--- a/src/minasss_games/experiments/awwwliens/view.cljs
+++ b/src/minasss_games/experiments/awwwliens/view.cljs
@@ -1,9 +1,9 @@
 (ns minasss-games.experiments.awwwliens.view
   (:require [minasss-games.director :as director]
+            [minasss-games.element :as element]
+            [minasss-games.experiments.awwwliens.core :as core]
             [minasss-games.pixi :as pixi]
-            [minasss-games.pixi.scene :as scene]
-            [minasss-games.tween :as tween]
-            [minasss-games.experiments.awwwliens.core :as core]))
+            [minasss-games.tween :as tween]))
 
 (def resources ["images/awwwliens/game/background.png"
                 "images/awwwliens/cow.png"
@@ -80,7 +80,7 @@
 
 (defn make-cell
   [{:keys [row col energy poison] :as cell}]
-  (let [container (scene/render
+  (let [container (element/render
                     [:container {:position [(* cell-width col) (* cell-height row)]}
                      [:sprite {:texture "images/awwwliens/game/tile.png"
                                :anchor [0 1]
@@ -123,7 +123,7 @@
 
 (defn make-cow-view [cow]
   (let [container
-        (scene/render
+        (element/render
           [:container {:position [(* cell-width (get-in cow [:position :col]))
                                   (* cell-height (get-in cow [:position :row]))]}
            [:sprite {:texture "images/awwwliens/cow.png"

--- a/src/minasss_games/experiments/harvest_bot/view.cljs
+++ b/src/minasss_games/experiments/harvest_bot/view.cljs
@@ -1,9 +1,9 @@
 (ns minasss-games.experiments.harvest-bot.view
   "this namespace collects all view related functions"
-  (:require [minasss-games.pixi :as pixi]
-            [minasss-games.pixi.scene :as scene]
-            [minasss-games.tween :as tween]
-            [minasss-games.experiments.harvest-bot.game :as game]))
+  (:require [minasss-games.element :as element]
+            [minasss-games.experiments.harvest-bot.game :as game]
+            [minasss-games.pixi :as pixi]
+            [minasss-games.tween :as tween]))
 
 (def resources ["images/background.png" "images/sprite.png" "images/tile.png" "images/gem.png"])
 
@@ -78,7 +78,7 @@
 
 (defn make-cell
   [{:keys [row col energy cost]}]
-  (let [container (scene/render
+  (let [container (element/render
                     [:container {:position [(* cell-size col) (* cell-size row)]}
                      [:sprite {:texture "images/tile.png"
                                :scale [4 4]}]
@@ -122,7 +122,7 @@
      :entities {:text text}}))
 
 (defn make-bot-view [bot]
-  (let [container (scene/render
+  (let [container (element/render
                     [:container {:position [(* cell-size (get-in bot [:position :col]))
                                             (* cell-size (get-in bot [:position :row]))]}
                      [:sprite {:texture "images/sprite.png"

--- a/src/minasss_games/pixi.cljs
+++ b/src/minasss_games/pixi.cljs
@@ -3,7 +3,6 @@
   (:require [cljsjs.pixi]
             [oops.core :refer [oget oget+ oset!]]))
 
-
 (def Loader (oget js/PIXI.Loader "shared"))
 (def Resources (oget Loader "resources"))
 (def Ticker (oget js/PIXI.Ticker "shared"))

--- a/src/minasss_games/pixi/settings.cljs
+++ b/src/minasss_games/pixi/settings.cljs
@@ -6,15 +6,15 @@
   properties using aget/aset"
   (:require [oops.core :refer [oget oget+ oset!+]]))
 
-(def Settings (oget js/PIXI "settings"))
-
 (defn get-by-name
   [name]
-  (oget+ Settings name))
+  (let [settings (oget js/PIXI "settings")]
+    (oget+ settings name)))
 
 (defn set-by-name!
   [name value]
-  (oset!+ Settings name value))
+  (let [settings (oget js/PIXI "settings")]
+    (oset!+ settings name value)))
 
 (defmulti set!
   (fn [setting _param] setting))


### PR DESCRIPTION
after the introduction of the scene concept in the director protocol
the pixi.scene namespace became a bit confusing because it was not
related to the director "scene"; element is probably a better name but
also not the best, in case something better will come up later I will
refactor again.
A bit surprisingly, I've a problem that some of the code depending on
PIXI was running before js/PIXI could be available so in director and
settings I disabled local caching of PIXI internal symbols; this may
affect performance, especially in the director namespace but, at this
time, performance is not an issue, may come back to this later in case
it will be needed