### PR TITLE
change the intro a little bit, add new set-attribute to screenplay

### DIFF
--- a/src/minasss_games/experiments/awwwliens/intro.cljs
+++ b/src/minasss_games/experiments/awwwliens/intro.cljs
@@ -29,22 +29,23 @@
 (def main-stage (pixi/make-container))
 
 (def intro-screenplay
-  [screenplay/action-after :time 1.5
-   :then [screenplay/action-move
-          :actor :ufo
-          :from [0 0] :to [248 200] :time 5.0
-          :then [screenplay/action-after
-                 :time 3.0
-                 :then [[screenplay/action-scale
-                         :actor :cow
-                         :from 0.1 :to 1.0 :time 4.0]
-                        [screenplay/action-move
-                         :actor :cow
-                         :from [248 200] :to [248 400] :time 4.0]
-                        [screenplay/action-after :time 4.0
-                         :then [screenplay/action-scale
-                                :actor :menu
-                                :from 0 :to 1.0 :time 0.7]]]]]])
+  [[::screenplay/set-attributes :actor :menu :scale 0.0]
+   [::screenplay/after :time 1.5
+    :then [::screenplay/move
+           :actor :ufo
+           :from [0 0] :to [260 200] :time 5.0
+           :then [::screenplay/after
+                  :time 3.0
+                  :then [[::screenplay/scale
+                          :actor :cow
+                          :from 0.1 :to 1.0 :time 4.0]
+                         [::screenplay/move
+                          :actor :cow
+                          :from [350 200] :to [350 430] :time 4.0]
+                         [::screenplay/after :time 4.0
+                          :then [::screenplay/scale
+                                 :actor :menu
+                                 :from 0 :to 1.0 :time 0.7]]]]]]])
 
 (comment
   (let [container (pixi/get-child-by-name main-stage "cow")]
@@ -75,20 +76,21 @@
   (element/render
     [:sprite {:texture "images/awwwliens/menu/cow-still.png"
               :position [-200 -400]
-              :pivot [0.5 0.5]
+              :anchor [0.5 0.0]
               :name "cow"}]))
 
-(def menu-items_ (atom {:selected-index 0
-                        :items [{:text "Press Enter\nTo Play" :position [-90 100]}
-                                {:text "Arrows\nWASD\nHJKL\nTo Move" :position [-90 200]}
-                                {:text "By Carmilla\nAnd Minasss" :position [-90 300]}]}))
+(def menu-items_
+  (atom {:selected-index 0
+         :items [{:text "Press Enter\nTo Play" :position [100 -350]}
+                 {:text "Arrows\nWASD\nHJKL\nTo Move" :position [100 -280]}
+                 {:text "By Carmilla\nAnd Minasss" :position [100 -150]}]}))
 
 (defn make-menu-entry
   [{:keys [text position]} selected]
   (let [color (if selected "#19d708" "#808284")
         [x y] position]
     [:text {:text text
-            :anchor [0.5 0.5]
+            :anchor [0.5 0.0]
             :position [(if selected (- x 20) x) y]
             :style {"fill" color "fontSize" 25}}]))
 
@@ -96,9 +98,8 @@
   [{:keys [selected-index items]}]
   (element/render
     [:sprite {:name "menu"
-              :anchor [1.0 0.0]
-              :position [590 50]
-              :scale 0
+              :anchor [0.0 1.0]
+              :position [392 480]
               :texture "images/awwwliens/menu/baloon.png"}
      (into [] (map-indexed #(make-menu-entry %2 (= %1 selected-index)) items))]))
 
@@ -149,9 +150,9 @@
     (pixi/add-child main-stage (make-animated-ufo))
     (pixi/add-child main-stage (make-menu @menu-items_))
 
-    (pixi/add-child app-stage main-stage)
-
     (screenplay/start intro-screenplay screenplay-listener)
+
+    (pixi/add-child app-stage main-stage)
     (add-watch menu-items_ ::menu-changed-watch menu-changed-listener)))
 
 (defmethod scene-cleanup ::menu

--- a/src/minasss_games/screenplay.cljs
+++ b/src/minasss_games/screenplay.cljs
@@ -148,7 +148,6 @@
 ;; after action just waits until the specified amount of time passes
 ;; and eventually continue with the actions specified in the :then
 ;; option
-(def action-after ::after)
 (defmethod make-action ::after
   [[action & options] listener]
   (let [{:keys [time then]} (apply hash-map options)
@@ -156,7 +155,6 @@
     (listener ::start action {:state initial-state})
     (register-action action listener then initial-state)))
 
-(def action-move ::move)
 (defmethod make-action ::move
   [[action & options] listener]
   (let [{:keys [actor from to time then]} (apply hash-map options) ;; options are provided as a vector but it is pratical to access them as a map
@@ -171,7 +169,6 @@
                                            :elapsed 0.0
                                            :time time})))
 
-(def action-scale ::scale)
 (defmethod make-action ::scale
   [[action & options] listener]
   (let [{:keys [actor from to time then]} (apply hash-map options)]
@@ -183,3 +180,13 @@
                                            :scale from
                                            :elapsed 0.0
                                            :time time})))
+
+;; this action is a bit particular, it is meant to be used to set
+;; actor properties once so the only event triggered by this
+;; action is ::start, so there is also no need to register itself
+(defmethod make-action ::set-attributes
+  [[action & options] listener]
+  (let [options-map (apply hash-map options)
+        actor (:actor options-map)
+        attributes (dissoc options-map :actor)]
+    (listener ::start action {:actor actor :state attributes})))


### PR DESCRIPTION
With the new set-attribute action in the screenplay namespace, it will be possible to set attributes, like scale, position, texture, etc of any actor; this opens many possibilities, like changing the sprite texture when an actor reaches its destination (after a ::move action for example) or hiding an actor that is already in the scene but needs to be shown at later point in time.

This opens other ideas like the ability to add/remove elements in the scene without pre-building them in the scene-ready handler